### PR TITLE
SOE-2296: Update help text to include class=iframe-auto

### DIFF
--- a/stanford_magazine.features.field_instance.inc
+++ b/stanford_magazine.features.field_instance.inc
@@ -17,10 +17,11 @@ function stanford_magazine_field_default_field_instances() {
     'deleted' => 0,
     'description' => '<p>This text area displays the featured image or video. </p>
 <p>To display an <strong>image</strong>: use the <strong>Featured image</strong> field to upload and insert an image.
-<p>To display a <strong>video</strong>:
+<p>To display a <strong>video</strong> or <strong>audio</strong> iFrame:
 <ol>
 <li>Select the <strong>Full HTML</strong> Text format</li>
-<li>Copy and paste the video embed code </li>
+<li>Copy and paste the embed code </li>
+<li>To override the fixed height add <em>class="iframe-auto"</em> after the iframe tag</li>
 </ol>
 </p>',
     'display' => array(

--- a/stanford_magazine.info
+++ b/stanford_magazine.info
@@ -15,6 +15,7 @@ dependencies[] = field_group
 dependencies[] = forward
 dependencies[] = image
 dependencies[] = link
+dependencies[] = list
 dependencies[] = options
 dependencies[] = paragraphs
 dependencies[] = pathauto


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This adds a line of help text to include "class=iframe-auto" 

# Needed By (Date)
- End of sprint 

# Criticality
- Needed for an editor to understand how to properly display audio.

# Steps to Test
- switch to this branch
- probably need to revert the feature
- Navigate to /node/add/stanford-magazine-article
- verify you see "to override the fixed height add class="iframe-auto" after the iframe tag"

# Affects 
- SoE

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-2296
https://stanfordits.atlassian.net/browse/SOE-2234
https://stanfordits.atlassian.net/browse/SOE-2231

## Related PRs
https://github.com/SU-SOE/stanford_soe_helper/pull/123
## More Information
- Track time on: https://stanfordits.atlassian.net/browse/SOE-2324
![screen shot 2017-10-11 at 11 55 26](https://user-images.githubusercontent.com/284440/31460419-412e49fc-ae7b-11e7-8f1d-192a347da620.png)


## Folks to notify
@kbrownell 

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)