### PR TITLE
added article date to admn view

### DIFF
--- a/modules/stanford_magazine_article_administration/stanford_magazine_article_administration.views_default.inc
+++ b/modules/stanford_magazine_article_administration/stanford_magazine_article_administration.views_default.inc
@@ -210,6 +210,19 @@ function stanford_magazine_article_administration_views_default_views() {
   $handler->display->display_options['fields']['changed']['table'] = 'node';
   $handler->display->display_options['fields']['changed']['field'] = 'changed';
   $handler->display->display_options['fields']['changed']['date_format'] = 'short';
+  /* Field: Content: Publishing Date */
+  $handler->display->display_options['fields']['field_s_mag_article_date']['id'] = 'field_s_mag_article_date';
+  $handler->display->display_options['fields']['field_s_mag_article_date']['table'] = 'field_data_field_s_mag_article_date';
+  $handler->display->display_options['fields']['field_s_mag_article_date']['field'] = 'field_s_mag_article_date';
+  $handler->display->display_options['fields']['field_s_mag_article_date']['label'] = 'Article Date';
+  $handler->display->display_options['fields']['field_s_mag_article_date']['settings'] = array(
+    'format_type' => 'short',
+    'fromto' => 'both',
+    'multiple_number' => '',
+    'multiple_from' => '',
+    'multiple_to' => '',
+    'show_remaining_days' => 0,
+  );
   /* Field: User: Name */
   $handler->display->display_options['fields']['name']['id'] = 'name';
   $handler->display->display_options['fields']['name']['table'] = 'users';


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
As a site author,
I want to view the "Manage Stanford Magazine Article" page 
and see a column with "publish" or "public" dates 
so that I can see the date that's being displayed on all Magazine Nodes

# Needed By (Date)
- Before Abracadabra code push

# Urgency
- Low

# Steps to Test
1. Pull branch to local
2. drush fr stanford_magazine_article_administration --force
3. Navigate to admin/manage/magazine_article
1. Check that 'Article Date' column exists and is populated with correct date published on node view

# Affected Projects or Products
- SOE

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-2309