### PR TITLE
SOE-2237 Added Research & Ideas label to homepage view

### DIFF
--- a/modules/stanford_magazine_article_views/stanford_magazine_article_views.views_default.inc
+++ b/modules/stanford_magazine_article_views/stanford_magazine_article_views.views_default.inc
@@ -220,7 +220,7 @@ function stanford_magazine_article_views_views_default_views() {
   $handler->display->display_options['fields']['nothing']['alter']['text'] = '<div class="mag-article-container">
   <div class="mag-article-img">[field_s_mag_article_image]</div>
     <div class="mag-article-content-container">
-      <div class="mag-article-date">[field_s_mag_article_date]</div>
+      <div class="mag-article-date">Research & Ideas - [field_s_mag_article_date]</div>
       <div class="mag-article-title"><h2>[title]</h2></div>
       <div class="mag-article-topics">[field_s_mag_article_topics]</div>
       <div class="edit-link">[edit_node]</div>

--- a/modules/stanford_magazine_article_views/stanford_magazine_article_views.views_default.inc
+++ b/modules/stanford_magazine_article_views/stanford_magazine_article_views.views_default.inc
@@ -220,7 +220,7 @@ function stanford_magazine_article_views_views_default_views() {
   $handler->display->display_options['fields']['nothing']['alter']['text'] = '<div class="mag-article-container">
   <div class="mag-article-img">[field_s_mag_article_image]</div>
     <div class="mag-article-content-container">
-      <div class="mag-article-date">Research & Ideas - [field_s_mag_article_date]</div>
+      <div class="mag-article-date">Research & Ideas – [field_s_mag_article_date]</div>
       <div class="mag-article-title"><h2>[title]</h2></div>
       <div class="mag-article-topics">[field_s_mag_article_topics]</div>
       <div class="edit-link">[edit_node]</div>


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- Added "Research & Ideas" label to homepage Featured DM Article view

# Needed By (Date)
- End of sprint (10/25)

# Urgency
- N/A

# Steps to Test

1. Pull this branch
2. Revert `stanford_magazine_article_views`
3. Verify that the homepage Featured DM Article block looks like mockup on ticket (InVision) or on related Google Doc (see links below)

# Affected Projects or Products
- stanford_magazine
- SOE

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-2237
- https://projects.invisionapp.com/d/main#/console/10423578/254415347/inspect
- https://docs.google.com/document/d/1LCuqHA9ZTsnGlPDHz0hGI1A5GgJu6VMQrxMfJZNyUn8/edit#heading=h.ukeg00a6zyb6

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)