### PR TITLE
SOE-2383: proof of concept for anchor scroll

### DIFF
--- a/modules/stanford_magazine_series/js/stanford_series_anchor_scroll.js
+++ b/modules/stanford_magazine_series/js/stanford_series_anchor_scroll.js
@@ -1,0 +1,13 @@
+(function($) {
+  Drupal.behaviors.stanfordseriesanchorscroll = {
+    attach: function(context, settings) {
+      $(".scroll-next").click(function() {
+        var nextArticle = $(this).find("a").attr("href");
+        console.log(nextArticle);
+        $("html, body").animate({
+          scrollTop: $(nextArticle).offset().top
+        }, 2000);
+      });
+    }
+  }
+})(jQuery);

--- a/modules/stanford_magazine_series/stanford_magazine_series.module
+++ b/modules/stanford_magazine_series/stanford_magazine_series.module
@@ -25,3 +25,18 @@ function stanford_magazine_series_preprocess_page(&$variables) {
     }
   }
 }
+
+/**
+ * Implements hook_preprocess_views_view().
+ *
+ * This adds the stanford_series_anchor_scroll.js when we're looking
+ * at the series view.
+ */
+function stanford_magazine_series_preprocess_views_view(&$vars) {
+  $view = $vars['view'];
+  if ($view->name == 'stanford_mag_series_article_list') {
+    $file_path = drupal_get_path('module', 'stanford_magazine_series')
+      . "/js/stanford_series_anchor_scroll.js";
+    drupal_add_js($file_path);
+  }
+}

--- a/modules/stanford_magazine_series/stanford_magazine_series.views_default.inc
+++ b/modules/stanford_magazine_series/stanford_magazine_series.views_default.inc
@@ -128,8 +128,8 @@ function stanford_magazine_series_views_default_views() {
   $handler->display->display_options['fields']['nothing_2']['label'] = '';
   $handler->display->display_options['fields']['nothing_2']['exclude'] = TRUE;
   $handler->display->display_options['fields']['nothing_2']['alter']['text'] = '<hr>
-<div id="[nothing]" class="menu-item">Part [counter] of [view] | [title_1] | <a href="#[nothing_1]">Jump to next </a></div>
-<hr>';
+<div id="[nothing]" class="menu-item">Part [counter] of [view] | [title_1] | <div class="scroll-next"><a href="#[nothing_1]">Jump to next </a></div></div>
+  <hr>';
   $handler->display->display_options['fields']['nothing_2']['element_label_colon'] = FALSE;
   /* Field: Content: Byline */
   $handler->display->display_options['fields']['field_s_mag_article_byline']['id'] = 'field_s_mag_article_byline';


### PR DESCRIPTION
# NOT READY

# Summary
- This slows down the scroll between series articles, previously navigation within the series jumped quickly between articles.

# Urgency
- This is part of ongoing work for a larger project.

# Steps to Test

1. Download this repository and checkout the SOE-2382-anchor-scroll branch.
2. Create a new Magazine Series at node/add/stanford-magazine-series.
3. Add a few Articles to your new Series.
4. After clicking Save, see if the "Jump to Next" inter-series navigation scrolls you to the next article.

# Affected Projects or Products
- SOE magazine series

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/SOE-2383
- This change is built on the work in: https://github.com/SU-SWS/stanford_magazine/pull/28