### PR TITLE
SOE-2762: add original image style

### DIFF
--- a/stanford_magazine.features.field_instance.inc
+++ b/stanford_magazine.features.field_instance.inc
@@ -775,7 +775,7 @@ function stanford_magazine_field_default_field_instances() {
           'colorbox__thmb-square' => 0,
           'colorbox__thumbnail' => 0,
           'icon_link' => 0,
-          'image' => 0,
+          'image' => 'image',
           'image_3-col-header' => 0,
           'image_4-col-header' => 0,
           'image_6-col-banner' => 0,


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- We want to be able to display GIFs.  To be able to display GIFs we need to use the original image size. This PR adds the original image size option to the featured image.

# Needed By (Date)
- ASAP

# Criticality
- Client is eagerly awaiting this.
- Fixes broken stuff

# Steps to Test
- Verify that the feature is not overridden
- Switch to this branch
- Revert feature
- Create a new magazine article
- Verify the `Original` image style is available for Features image
- Upload a .gif file
- Insert the .gif in the body field
- Save and verify that the Gif animates as expected.

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)
https://stanfordits.atlassian.net/browse/SOE-2762

## Related PRs

## More Information

## Folks to notify
@minorwm


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)